### PR TITLE
Add concept for chainRec implementation

### DIFF
--- a/docs/modules/Future.ts.md
+++ b/docs/modules/Future.ts.md
@@ -39,7 +39,7 @@ Added in v0.5.0
 **Signature**
 
 ```ts
-export const future: Monad2<URI> & Bifunctor2<URI> & Alt2<URI> = ...
+export const future: Monad2<URI> & Bifunctor2<URI> & ChainRec2<URI> & Alt2<URI> = ...
 ```
 
 Added in v0.5.0

--- a/src/Future.ts
+++ b/src/Future.ts
@@ -1,9 +1,9 @@
 import * as F from 'fluture'
 import { Alt2 } from 'fp-ts/lib/Alt'
 import { Bifunctor2 } from 'fp-ts/lib/Bifunctor'
-import { ChainRec2 } from 'fp-ts/lib/ChainRec' 
+import { ChainRec2 } from 'fp-ts/lib/ChainRec'
 import { Monad2 } from 'fp-ts/lib/Monad'
-import { Either, fold } from 'fp-ts/lib/Either' 
+import { Either, fold } from 'fp-ts/lib/Either'
 
 declare module 'fp-ts/lib/HKT' {
   interface URItoKind2<E, A> {

--- a/src/Future.ts
+++ b/src/Future.ts
@@ -34,7 +34,7 @@ export const future: Monad2<URI> & Bifunctor2<URI> & ChainRec2<URI> & Alt2<URI> 
   mapLeft: (fea, f) => F.mapRej(f)(fea),
   alt: (fx, f) => F.alt(f())(fx),
   chainRec: <E, A, B>(a: A, f: (a: A) => F.FutureInstance<E, Either<A, B>>): F.FutureInstance<E, B> =>
-    (function recur(x: A): F.FutureInstance<E, B>{
-      return F.chain(fold(recur, F.resolve))(f(x))
-    }(a))
+    (function recur(a: A): F.FutureInstance<E, B> {
+      return future.chain(f(a), fold(recur, F.resolve))
+    })(a)
 }

--- a/src/Future.ts
+++ b/src/Future.ts
@@ -1,7 +1,9 @@
 import * as F from 'fluture'
 import { Alt2 } from 'fp-ts/lib/Alt'
 import { Bifunctor2 } from 'fp-ts/lib/Bifunctor'
+import { ChainRec2 } from 'fp-ts/lib/ChainRec' 
 import { Monad2 } from 'fp-ts/lib/Monad'
+import { Either, fold } from 'fp-ts/lib/Either' 
 
 declare module 'fp-ts/lib/HKT' {
   interface URItoKind2<E, A> {
@@ -22,7 +24,7 @@ export type URI = typeof URI
 /**
  * @since 0.5.0
  */
-export const future: Monad2<URI> & Bifunctor2<URI> & Alt2<URI> = {
+export const future: Monad2<URI> & Bifunctor2<URI> & ChainRec2<URI> & Alt2<URI> = {
   URI,
   map: (fa, f) => F.map(f)(fa),
   of: F.resolve,
@@ -30,5 +32,9 @@ export const future: Monad2<URI> & Bifunctor2<URI> & Alt2<URI> = {
   chain: (fa, f) => F.chain(f)(fa),
   bimap: (fea, f, g) => F.bimap(f)(g)(fea),
   mapLeft: (fea, f) => F.mapRej(f)(fea),
-  alt: (fx, f) => F.alt(f())(fx)
+  alt: (fx, f) => F.alt(f())(fx),
+  chainRec: <E, A, B>(a: A, f: (a: A) => F.FutureInstance<E, Either<A, B>>): F.FutureInstance<E, B> =>
+    (function recur(x: A): F.FutureInstance<E, B>{
+      return F.chain(fold(recur, F.resolve))(f(x))
+    }(a))
 }


### PR DESCRIPTION
Since `chain` in Fluture is stacksafe by itself, there is no need to implement `chainRec` on top of `fantasy-land/chainRec`.