### PR TITLE
Improve interoperability

### DIFF
--- a/docs/modules/ConcurrentFuture.ts.md
+++ b/docs/modules/ConcurrentFuture.ts.md
@@ -13,8 +13,8 @@ Added in v0.5.0
 <h2 class="text-delta">Table of contents</h2>
 
 - [URI (type alias)](#uri-type-alias)
-- [URI](#uri)
-- [concurrentFuture](#concurrentfuture)
+- [URI (constant)](#uri-constant)
+- [concurrentFuture (constant)](#concurrentfuture-constant)
 
 ---
 
@@ -28,7 +28,7 @@ export type URI = typeof URI
 
 Added in v0.5.0
 
-# URI
+# URI (constant)
 
 **Signature**
 
@@ -38,7 +38,7 @@ export const URI: "Fluture/ConcurrentFuture" = ...
 
 Added in v0.5.0
 
-# concurrentFuture
+# concurrentFuture (constant)
 
 **Signature**
 

--- a/docs/modules/Future.ts.md
+++ b/docs/modules/Future.ts.md
@@ -12,11 +12,46 @@ Added in v0.5.0
 
 <h2 class="text-delta">Table of contents</h2>
 
+- [Future (interface)](#future-interface)
 - [URI (type alias)](#uri-type-alias)
-- [URI](#uri)
-- [future](#future)
+- [URI (constant)](#uri-constant)
+- [future (constant)](#future-constant)
+- [left (constant)](#left-constant)
+- [right (constant)](#right-constant)
+- [rightIO (constant)](#rightio-constant)
+- [rightTask (constant)](#righttask-constant)
+- [swap (constant)](#swap-constant)
+- [delay (function)](#delay-function)
+- [fold (function)](#fold-function)
+- [futurify (function)](#futurify-function)
+- [leftIO (function)](#leftio-function)
+- [leftTask (function)](#lefttask-function)
+- [orElse (function)](#orelse-function)
+- [alt (export)](#alt-export)
+- [ap (export)](#ap-export)
+- [apFirst (export)](#apfirst-export)
+- [apSecond (export)](#apsecond-export)
+- [bimap (export)](#bimap-export)
+- [chain (export)](#chain-export)
+- [chainFirst (export)](#chainfirst-export)
+- [flatten (export)](#flatten-export)
+- [fromEither (export)](#fromeither-export)
+- [fromOption (export)](#fromoption-export)
+- [fromPredicate (export)](#frompredicate-export)
+- [map (export)](#map-export)
+- [mapLeft (export)](#mapleft-export)
 
 ---
+
+# Future (interface)
+
+**Signature**
+
+```ts
+export interface Future<E, A> extends F.FutureInstance<E, A> {}
+```
+
+Added in v0.6.4
 
 # URI (type alias)
 
@@ -28,7 +63,7 @@ export type URI = typeof URI
 
 Added in v0.5.0
 
-# URI
+# URI (constant)
 
 **Signature**
 
@@ -38,12 +73,270 @@ export const URI: "Fluture/Future" = ...
 
 Added in v0.5.0
 
-# future
+# future (constant)
 
 **Signature**
 
 ```ts
-export const future: Monad2<URI> & Bifunctor2<URI> & ChainRec2<URI> & Alt2<URI> = ...
+export const future: Monad2<URI> & Bifunctor2<URI> & ChainRec2<URI> & Alt2<URI> & MonadThrow2<URI> & MonadTask2<URI> = ...
 ```
 
 Added in v0.5.0
+
+# left (constant)
+
+**Signature**
+
+```ts
+export const left: <E = ...
+```
+
+Added in v0.6.4
+
+# right (constant)
+
+**Signature**
+
+```ts
+export const right: <E = ...
+```
+
+Added in v0.6.4
+
+# rightIO (constant)
+
+**Signature**
+
+```ts
+export const rightIO: <E = ...
+```
+
+Added in v0.6.4
+
+# rightTask (constant)
+
+**Signature**
+
+```ts
+export const rightTask: <E = ...
+```
+
+Added in v0.6.4
+
+# swap (constant)
+
+**Signature**
+
+```ts
+export const swap: <E, A>(ma: Future<E, A>) => Future<A, E> = ...
+```
+
+Added in v0.6.4
+
+# delay (function)
+
+**Signature**
+
+```ts
+export function delay(millis: number): <A>(ma: Future<never, A>) => Future<never, A> { ... }
+```
+
+Added in v0.6.4
+
+# fold (function)
+
+**Signature**
+
+```ts
+export function fold<E, A, B>(
+  onLeft: (left: E) => Task<B>,
+  onRight: (right: A) => Task<B>
+): (ma: Future<E, A>) => Task<B> { ... }
+```
+
+Added in v0.6.4
+
+# futurify (function)
+
+**Signature**
+
+```ts
+export function futurify<L, R>(f: (cb: (e: L | null | undefined, r?: R) => void) => void): () => Future<L, R>
+export function futurify<A, L, R>(
+  f: (a: A, cb: (e: L | null | undefined, r?: R) => void) => void
+): (a: A) => Future<L, R>
+export function futurify<A, B, L, R>(
+  f: (a: A, b: B, cb: (e: L | null | undefined, r?: R) => void) => void
+): (a: A, b: B) => Future<L, R>
+export function futurify<A, B, C, L, R>(
+  f: (a: A, b: B, c: C, cb: (e: L | null | undefined, r?: R) => void) => void
+): (a: A, b: B, c: C) => Future<L, R>
+export function futurify<A, B, C, D, L, R>(
+  f: (a: A, b: B, c: C, d: D, cb: (e: L | null | undefined, r?: R) => void) => void
+): (a: A, b: B, c: C, d: D) => Future<L, R>
+export function futurify<A, B, C, D, E, L, R>(
+  f: (a: A, b: B, c: C, d: D, e: E, cb: (e: L | null | undefined, r?: R) => void) => void
+): (a: A, b: B, c: C, d: D, e: E) => Future<L, R> { ... }
+```
+
+Added in v0.6.4
+
+# leftIO (function)
+
+**Signature**
+
+```ts
+export function leftIO<E = never, A = never>(ma: IO<E>): Future<E, A> { ... }
+```
+
+Added in v0.6.4
+
+# leftTask (function)
+
+**Signature**
+
+```ts
+export function leftTask<E = never, A = never>(ma: Task<E>): Future<E, A> { ... }
+```
+
+Added in v0.6.4
+
+# orElse (function)
+
+**Signature**
+
+```ts
+export function orElse<E, A, M>(onLeft: (e: E) => Future<M, A>): (ma: Future<E, A>) => Future<M, A> { ... }
+```
+
+Added in v0.6.4
+
+# alt (export)
+
+**Signature**
+
+```ts
+<E, A>(that: () => Future<E, A>) => (fa: Future<E, A>) => Future<E, A>
+```
+
+Added in v0.6.4
+
+# ap (export)
+
+**Signature**
+
+```ts
+<E, A>(fa: Future<E, A>) => <B>(fab: Future<E, (a: A) => B>) => Future<E, B>
+```
+
+Added in v0.6.4
+
+# apFirst (export)
+
+**Signature**
+
+```ts
+<E, B>(fb: Future<E, B>) => <A>(fa: Future<E, A>) => Future<E, A>
+```
+
+Added in v0.6.4
+
+# apSecond (export)
+
+**Signature**
+
+```ts
+<E, B>(fb: Future<E, B>) => <A>(fa: Future<E, A>) => Future<E, B>
+```
+
+Added in v0.6.4
+
+# bimap (export)
+
+**Signature**
+
+```ts
+<E, G, A, B>(f: (e: E) => G, g: (a: A) => B) => (fa: Future<E, A>) => Future<G, B>
+```
+
+Added in v0.6.4
+
+# chain (export)
+
+**Signature**
+
+```ts
+<E, A, B>(f: (a: A) => Future<E, B>) => (ma: Future<E, A>) => Future<E, B>
+```
+
+Added in v0.6.4
+
+# chainFirst (export)
+
+**Signature**
+
+```ts
+<E, A, B>(f: (a: A) => Future<E, B>) => (ma: Future<E, A>) => Future<E, A>
+```
+
+Added in v0.6.4
+
+# flatten (export)
+
+**Signature**
+
+```ts
+<E, A>(mma: Future<E, Future<E, A>>) => Future<E, A>
+```
+
+Added in v0.6.4
+
+# fromEither (export)
+
+**Signature**
+
+```ts
+<E, A>(ma: E.Either<E, A>) => Future<E, A>
+```
+
+Added in v0.6.4
+
+# fromOption (export)
+
+**Signature**
+
+```ts
+<E>(onNone: () => E) => <A>(ma: Option<A>) => Future<E, A>
+```
+
+Added in v0.6.4
+
+# fromPredicate (export)
+
+**Signature**
+
+```ts
+{ <E, A, B>(refinement: Refinement<A, B>, onFalse: (a: A) => E): (a: A) => Future<E, B>; <E, A>(predicate: Predicate<A>, onFalse: (a: A) => E): (a: A) => Future<E, A>; }
+```
+
+Added in v0.6.4
+
+# map (export)
+
+**Signature**
+
+```ts
+<A, B>(f: (a: A) => B) => <E>(fa: Future<E, A>) => Future<E, B>
+```
+
+Added in v0.6.4
+
+# mapLeft (export)
+
+**Signature**
+
+```ts
+<E, G>(f: (e: E) => G) => <A>(fa: Future<E, A>) => Future<G, A>
+```
+
+Added in v0.6.4

--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -12,12 +12,12 @@ Added in v0.5.0
 
 <h2 class="text-delta">Table of contents</h2>
 
-- [concurrentFuture](#concurrentfuture)
-- [future](#future)
+- [concurrentFuture (export)](#concurrentfuture-export)
+- [future (export)](#future-export)
 
 ---
 
-# concurrentFuture
+# concurrentFuture (export)
 
 Exports the whole `ConcurrentFuture.ts` module
 
@@ -29,7 +29,7 @@ typeof concurrentFuture
 
 Added in v0.5.0
 
-# future
+# future (export)
 
 Exports the whole `Future.ts` module
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -604,9 +604,9 @@
       "dev": true
     },
     "fp-ts": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.0.0.tgz",
-      "integrity": "sha512-oz8L+EZiztqGVLhgdL+63b4hpfdJkEKH/4vRoS/AuUwYqmn7vHAzWMu1jtoYfB0pPxo5UioWVT2XOuftyivUSQ==",
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.4.4.tgz",
+      "integrity": "sha512-J5wFa/BzT57A+DIvwAYS5LTsbRiXsvF9hsefP3ZfzsHLuWGjtHAheG1WscG1tX3og1PDZyv6mZAUTlpH1MmHhA==",
       "dev": true
     },
     "fs-extra": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@types/node": "^12.12.11",
     "docs-ts": "^0.3.4",
     "fluture": "^12.0.2",
-    "fp-ts": "^2.0.0",
+    "fp-ts": "^2.4.4",
     "import-path-rewrite": "github:gcanti/import-path-rewrite",
     "mocha": "3.2.0",
     "prettier": "^1.19.1",

--- a/src/Future.ts
+++ b/src/Future.ts
@@ -2,15 +2,20 @@
  * @since 0.5.0
  */
 import * as F from 'fluture'
+import * as E from 'fp-ts/lib/Either'
+import { Task } from 'fp-ts/lib/Task'
+import { IO } from 'fp-ts/lib/IO'
 import { Alt2 } from 'fp-ts/lib/Alt'
 import { Bifunctor2 } from 'fp-ts/lib/Bifunctor'
 import { ChainRec2 } from 'fp-ts/lib/ChainRec'
 import { Monad2 } from 'fp-ts/lib/Monad'
-import { Either, fold } from 'fp-ts/lib/Either'
+import { pipeable } from 'fp-ts/lib/pipeable'
+import { MonadThrow2 } from 'fp-ts/lib/MonadThrow'
+import { MonadTask2 } from 'fp-ts/lib/MonadTask'
 
 declare module 'fp-ts/lib/HKT' {
   interface URItoKind2<E, A> {
-    'Fluture/Future': F.FutureInstance<E, A>
+    'Fluture/Future': Future<E, A>
   }
 }
 
@@ -20,6 +25,96 @@ declare module 'fp-ts/lib/HKT' {
 export const URI = 'Fluture/Future'
 
 /**
+ * @since 0.6.4
+ */
+export interface Future<E, A> extends F.FutureInstance<E, A> {}
+
+/**
+ * @since 0.6.4
+ */
+export const left: <E = never, A = never>(e: E) => Future<E, A> = F.reject
+
+/**
+ * @since 0.6.4
+ */
+export const right: <E = never, A = never>(a: A) => Future<E, A> = F.resolve
+
+/**
+ * @since 0.6.4
+ */
+export function leftIO<E = never, A = never>(ma: IO<E>): Future<E, A> {
+  return F.swap(F.attempt(ma))
+}
+
+/**
+ * @since 0.6.4
+ */
+export const rightIO: <E = never, A = never>(ma: IO<A>) => Future<E, A> = F.attempt
+
+/**
+ * @since 0.6.4
+ */
+export function leftTask<E = never, A = never>(ma: Task<E>): Future<E, A> {
+  return F.swap(F.attemptP(ma))
+}
+
+/**
+ * @since 0.6.4
+ */
+export const rightTask: <E = never, A = never>(ma: Task<A>) => Future<E, A> = F.attemptP
+
+/**
+ * @since 0.6.4
+ */
+export function orElse<E, A, M>(onLeft: (e: E) => Future<M, A>): (ma: Future<E, A>) => Future<M, A> {
+  return F.chainRej(onLeft)
+}
+
+/**
+ * @since 0.6.4
+ */
+export function fold<E, A, B>(
+  onLeft: (left: E) => Task<B>,
+  onRight: (right: A) => Task<B>
+): (ma: Future<E, A>) => Task<B> {
+  return ma => () => F.promise(F.coalesce<E, Task<B>>(onLeft)(onRight)(ma)).then(mb => mb())
+}
+
+/**
+ * @since 0.6.4
+ */
+export const swap: <E, A>(ma: Future<E, A>) => Future<A, E> = F.swap
+
+/**
+ * @since 0.6.4
+ */
+export function futurify<L, R>(f: (cb: (e: L | null | undefined, r?: R) => void) => void): () => Future<L, R>
+export function futurify<A, L, R>(
+  f: (a: A, cb: (e: L | null | undefined, r?: R) => void) => void
+): (a: A) => Future<L, R>
+export function futurify<A, B, L, R>(
+  f: (a: A, b: B, cb: (e: L | null | undefined, r?: R) => void) => void
+): (a: A, b: B) => Future<L, R>
+export function futurify<A, B, C, L, R>(
+  f: (a: A, b: B, c: C, cb: (e: L | null | undefined, r?: R) => void) => void
+): (a: A, b: B, c: C) => Future<L, R>
+export function futurify<A, B, C, D, L, R>(
+  f: (a: A, b: B, c: C, d: D, cb: (e: L | null | undefined, r?: R) => void) => void
+): (a: A, b: B, c: C, d: D) => Future<L, R>
+export function futurify<A, B, C, D, E, L, R>(
+  f: (a: A, b: B, c: C, d: D, e: E, cb: (e: L | null | undefined, r?: R) => void) => void
+): (a: A, b: B, c: C, d: D, e: E) => Future<L, R>
+export function futurify<L, R>(f: Function): () => Future<L, R> {
+  return function() {
+    const args = Array.prototype.slice.call(arguments)
+    return F.node(done => {
+      const cbResolver = (e: L, r: R) => (e != null ? done(e) : done(null, r))
+      f.apply(null, args.concat(cbResolver))
+    })
+  }
+}
+
+/**
  * @since 0.5.0
  */
 export type URI = typeof URI
@@ -27,7 +122,7 @@ export type URI = typeof URI
 /**
  * @since 0.5.0
  */
-export const future: Monad2<URI> & Bifunctor2<URI> & ChainRec2<URI> & Alt2<URI> = {
+export const future: Monad2<URI> & Bifunctor2<URI> & ChainRec2<URI> & Alt2<URI> & MonadThrow2<URI> & MonadTask2<URI> = {
   URI,
   map: (fa, f) => F.map(f)(fa),
   of: F.resolve,
@@ -36,8 +131,89 @@ export const future: Monad2<URI> & Bifunctor2<URI> & ChainRec2<URI> & Alt2<URI> 
   bimap: (fea, f, g) => F.bimap(f)(g)(fea),
   mapLeft: (fea, f) => F.mapRej(f)(fea),
   alt: (fx, f) => F.alt(f())(fx),
-  chainRec: <E, A, B>(a: A, f: (a: A) => F.FutureInstance<E, Either<A, B>>): F.FutureInstance<E, B> =>
-    (function recur(a: A): F.FutureInstance<E, B> {
-      return future.chain(f(a), fold(recur, F.resolve))
-    })(a)
+  chainRec: <E, A, B>(a: A, f: (a: A) => Future<E, E.Either<A, B>>): Future<E, B> =>
+    (function recur(a: A): Future<E, B> {
+      return future.chain(f(a), E.fold(recur, F.resolve))
+    })(a),
+  throwError: left,
+  fromTask: F.attemptP,
+  fromIO: F.attempt
+}
+
+/**
+ * @since 0.6.4
+ */
+export function delay(millis: number): <A>(ma: Future<never, A>) => Future<never, A> {
+  return chain(F.after(millis))
+}
+
+const {
+  alt,
+  ap,
+  apFirst,
+  apSecond,
+  bimap,
+  chain,
+  chainFirst,
+  flatten,
+  map,
+  mapLeft,
+  fromEither,
+  fromOption,
+  fromPredicate
+} = pipeable(future)
+
+export {
+  /**
+   * @since 0.6.4
+   */
+  alt,
+  /**
+   * @since 0.6.4
+   */
+  ap,
+  /**
+   * @since 0.6.4
+   */
+  apFirst,
+  /**
+   * @since 0.6.4
+   */
+  apSecond,
+  /**
+   * @since 0.6.4
+   */
+  bimap,
+  /**
+   * @since 0.6.4
+   */
+  chain,
+  /**
+   * @since 0.6.4
+   */
+  chainFirst,
+  /**
+   * @since 0.6.4
+   */
+  flatten,
+  /**
+   * @since 0.6.4
+   */
+  map,
+  /**
+   * @since 0.6.4
+   */
+  mapLeft,
+  /**
+   * @since 0.6.4
+   */
+  fromEither,
+  /**
+   * @since 0.6.4
+   */
+  fromOption,
+  /**
+   * @since 0.6.4
+   */
+  fromPredicate
 }

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,13 +1,91 @@
 import * as assert from 'assert'
-import { ConcurrentFutureInstance, promise, reject, resolve, FutureInstance } from 'fluture'
+import { ConcurrentFutureInstance, fork, promise, reject, resolve, FutureInstance } from 'fluture'
 import { array } from 'fp-ts/lib/Array'
-import { concurrentFuture } from '../src/ConcurrentFuture'
-import { future } from '../src/Future'
 import { left, right } from 'fp-ts/lib/Either'
+import { pipe } from 'fp-ts/lib/pipeable'
+import * as _ from '../src/Future'
+import { concurrentFuture } from '../src/ConcurrentFuture'
+
+const double = (n: number): number => n * 2
 
 describe('Future', () => {
+  describe('Monad', () => {
+    it('map', done => {
+      fork(done)(x => {
+        assert.deepStrictEqual(x, 2)
+        done()
+      })(_.future.map(_.right(1), double))
+    })
+
+    it('ap', done => {
+      const mab = _.right(double)
+      const ma = _.right(1)
+      fork(done)(x => {
+        assert.deepStrictEqual(x, 2)
+        done()
+      })(_.future.ap(mab, ma))
+    })
+
+    it('chain', done => {
+      const ma = _.future.chain(_.right('foo'), a => (a.length > 2 ? _.right(a.length) : _.left('foo')))
+      const mab = _.future.chain(_.right('a'), a => (a.length > 2 ? _.right(a.length) : _.left('foo')))
+
+      fork(done)(e1 => {
+        assert.deepStrictEqual(e1, 3)
+        fork(e2 => {
+          assert.deepStrictEqual(e2, 'foo')
+          done()
+        })(done)(mab)
+      })(ma)
+    })
+  })
+
+  describe('Bifunctor', () => {
+    it('bimap', done => {
+      const f = (s: string): number => s.length
+      const g = (n: number): boolean => n > 2
+
+      const ma = _.bimap(f, g)(_.right(1))
+      const mab = _.bimap(f, g)(_.left('foo'))
+
+      fork(done)(e1 => {
+        assert.deepStrictEqual(e1, false)
+        fork(e2 => {
+          assert.deepStrictEqual(e2, 3)
+          done()
+        })(done)(mab)
+      })(ma)
+    })
+
+    it('mapLeft', done => {
+      fork(x => {
+        assert.deepStrictEqual(x, 2)
+        done()
+      })(done)(_.future.mapLeft(_.left(1), double))
+    })
+  })
+
+  it('orElse', done => {
+    const e1 = pipe(
+      _.left('foo'),
+      _.orElse(l => _.right(l.length))
+    )
+    const e2 = pipe(
+      _.right(1),
+      _.orElse(() => _.right(2))
+    )
+
+    fork(done)(x => {
+      assert.deepStrictEqual(x, 3)
+      fork(done)(x => {
+        assert.deepStrictEqual(x, 1)
+        done()
+      })(e2)
+    })(e1)
+  })
+
   it('should work with sequence (failure case)', done => {
-    promise(array.sequence(future)([resolve(1), reject(new Error('ops'))]))
+    promise(array.sequence(_.future)([resolve(1), reject(new Error('ops'))]))
       .then(() => {
         done(new Error('Expected rejection'))
       })
@@ -19,14 +97,14 @@ describe('Future', () => {
   })
 
   it('should work with sequence (success case)', async () => {
-    const xs = await promise(array.sequence(future)([resolve(1), resolve(2)]))
+    const xs = await promise(array.sequence(_.future)([resolve(1), resolve(2)]))
     assert.deepEqual(xs, [1, 2])
   })
 
   it('should export an Alt instance', async () => {
-    const f1: FutureInstance<Error, number> = future.alt(resolve(1), () => resolve(2))
-    const f2: FutureInstance<Error, number> = future.alt(reject(new Error('1')), () => resolve(2))
-    const f3: FutureInstance<Error, number> = future.alt(reject(new Error('1')), () => reject(new Error('2')))
+    const f1: FutureInstance<Error, number> = _.future.alt(resolve(1), () => resolve(2))
+    const f2: FutureInstance<Error, number> = _.future.alt(reject(new Error('1')), () => resolve(2))
+    const f3: FutureInstance<Error, number> = _.future.alt(reject(new Error('1')), () => reject(new Error('2')))
     const n1 = await promise(f1)
     const n2 = await promise(f2)
     const n3 = await promise(f3).catch(() => 3)
@@ -34,8 +112,36 @@ describe('Future', () => {
   })
 
   it('should export a ChainRec instance', async () => {
-    const ma = future.chainRec(0, n => resolve(n < 20_000 ? left(n + 1) : right(n)))
+    const ma = _.future.chainRec(0, n => resolve(n < 20_000 ? left(n + 1) : right(n)))
     assert.strictEqual(await promise(ma), 20000)
+  })
+
+  it('futurify', done => {
+    const api1 = (_path: string, callback: (err: Error | null | undefined, result?: string) => void): void => {
+      callback(null, 'ok')
+    }
+    const api2 = (_path: string, callback: (err: Error | null | undefined, result?: string) => void): void => {
+      callback(undefined, 'ok')
+    }
+    const api3 = (_path: string, callback: (err: Error | null | undefined, result?: string) => void): void => {
+      callback(new Error('ko'))
+    }
+    promise(_.futurify(api1)('foo'))
+      .then(e1 => {
+        assert.deepStrictEqual(e1, 'ok')
+        promise(_.futurify(api2)('foo'))
+          .then(e2 => {
+            assert.deepStrictEqual(e2, 'ok')
+            promise(_.futurify(api3)('foo'))
+              .catch(e3 => {
+                assert.deepStrictEqual(e3, new Error('ko'))
+                done()
+              })
+              .catch(done)
+          })
+          .catch(done)
+      })
+      .catch(done)
   })
 })
 


### PR DESCRIPTION
partially copy-pasted some of the methods found in `TaskEither` that were missing in this module.

looking forward for your feedback @gcanti @Avaq 

## Changes

* Add `MonadTask`
* Add `MonadThrow`
* Add `fold`
* Add pipeable methods
* Add `futurify`
* Upgrade to the latest fp-ts (^2.4.4)
